### PR TITLE
Remove deprecated frameworks

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -267,7 +267,7 @@ subtitle: OOO, FP, Testing, Types, Package Management, And More
     <section>
         <p>So. Many. Frameworks.</p>
 
-        <p>Cake, CodeIgniter, Drupal, eZ, Fuel, Joomla, Kohana, Laravel, Lumen, Midgard, Moodle, Nette, Phalcon, Silex, SilverStripe, Slim, Symfony, TYPO3, Yii, WordPress, Zend</p>
+        <p>Cake, CodeIgniter, Drupal, eZ, Fuel, Joomla, Laravel, Lumen, Midgard, Moodle, Nette, Phalcon, SilverStripe, Slim, Symfony, TYPO3, Yii, WordPress, Zend</p>
     </section>
 
     <section>


### PR DESCRIPTION
Hello, I've noticed that there are listed also two frameworks which are no longer operative nor supported. 

They are replaced with their upstream sources though:
- Silex with Symfony and Flex
and
- Kohana with CodeIgniter maybe

Maybe it would be a good idea to remove them and add some new ones also instead. Thanks.